### PR TITLE
FEAT: logger debug examples added config and main

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,3 +1,7 @@
+from loguru import logger
+
+logger.debug("Config params read")
+
 SCREEN_WIDTH = 320
 SCREEN_HEIGHT = 240
 REFRESH_RATE_HZ = 100

--- a/main.py
+++ b/main.py
@@ -2,6 +2,8 @@ import pygame
 from tools import Pencil, Line, Circle, Type
 import config
 from bitmapfont import BitmapFont
+from loguru import logger
+import settings
 
 ''' App: contains several Scenes
     Scene: describes a particular stage of an App, does not necessarily display anything
@@ -14,10 +16,6 @@ SCREEN_WIDTH = config.SCREEN_WIDTH
 SCREEN_HEIGHT = config.SCREEN_HEIGHT
 
 BOTTOM_BAR_Y_POS = config.SCREEN_HEIGHT - config.FONT_HEIGHT
-
-
-
-
 
 
 class Display:
@@ -147,5 +145,10 @@ def main():
     a = App()
     a.run()
 
+def example_func():
+    a = 5 * 5
+    logger.debug(f"Some useful info: {a}")
+
 if __name__ == '__main__':
-    main()
+    # main()
+    example_func()

--- a/settings/__init__.py
+++ b/settings/__init__.py
@@ -1,0 +1,29 @@
+from loguru import logger
+import sys
+from pathlib import Path
+
+# obsfuscate file path
+p = Path(__file__)
+serial_logloc = p.parent / "logs/serialized.log"
+debug_logloc = p.parent / "logs/debug.log"
+
+
+# logger configuration called from main
+config = {
+    "handlers": [
+        {"sink": sys.stdout, "format": "<yellow>{time:YYYY-MM-DD at HH:mm:ss}</> | <level>{level}</level>    | <green>{module}</>:<green>{function}</>:<green>{line}</> - <blue>{message}</> | {elapsed.seconds}"},
+        # {"sink": serial_logloc, "serialize": True},
+        {"sink": debug_logloc, "format": "<yellow>{time:YYYY-MM-DD at HH:mm:ss}</> | <level>{level}</level>    | <green>{module}</>:<green>{function}</>:<green>{line}</> - <blue>{message}</> | {elapsed.seconds}"}
+    ],
+    "extra": {"user": "Don Huelo"},
+}
+
+# instantiate global logger configs
+logger.configure(**config)
+
+if __name__ == "__main__":
+    logger.success(f"Logger setup from {p.resolve()}")
+    logger.debug(f"serial_logloc: {serial_logloc}")
+    logger.debug(f"debug_logloc: {serial_logloc}")
+
+    

--- a/settings/logs/debug.log
+++ b/settings/logs/debug.log
@@ -1,0 +1,4 @@
+2022-05-10 at 20:16:26 | SUCCESS    | __init__:<module>:25 - Logger setup from /home/izzlee/repos/simple_paint/settings/__init__.py | 0
+2022-05-10 at 20:16:26 | DEBUG    | __init__:<module>:26 - serial_logloc: /home/izzlee/repos/simple_paint/settings/logs/serialized.log | 0
+2022-05-10 at 20:16:26 | DEBUG    | __init__:<module>:27 - debug_logloc: /home/izzlee/repos/simple_paint/settings/logs/serialized.log | 0
+2022-05-10 at 20:20:15 | DEBUG    | main:example_func:150 - Some useful info: 25 | 0


### PR DESCRIPTION
Nice logger alternative to use for dev. This is a sweet alternative to the built in logger. Rumours are it will be faster than built in soon too.

I've silenced main() function from main.py as an example of the output from the logger. 

To run and see useful logger hints just run main.py of this pull request. You should see some nicely formatted messages including `module:function:line number`

![image](https://user-images.githubusercontent.com/72337941/167608149-edc424de-4118-47cf-992d-7358034fa6e4.png)

[To turn these off](https://loguru.readthedocs.io/en/latest/resources/recipes.html#changing-the-level-of-an-existing-handler) you can just set the level to WARNING or something higher than debug and they won't show
